### PR TITLE
README: core tests require quicklisp

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ as node and a possible server side Boxer).
 ### macOS
 
 - Install Lispworks 7.1.2, including the most up to date patches for macOS Big Sur and Monterey
-- Install Quicklisp
+- [Install Quicklisp](https://www.quicklisp.org/beta/#installation)
 - Install our patched cl-freetype project
 
   ```

--- a/README.md
+++ b/README.md
@@ -110,13 +110,14 @@ Examples of running the unit tests on ECL, SBCL, and Lispworks are below:
 # I like to wrap these in rlwrap in case I need to use the REPL, but it's optional
 
 #ECL
-rlwrap ecl --load ./run-core-tests.lisp
+rlwrap ecl --load ~/quicklisp/setup.lisp --load ./run-core-tests.lisp
 
 #SBCL
-rlwrap sbcl --load ./run-core-tests.lisp
+rlwrap sbcl --load ~/quicklisp/setup.lisp --load ./run-core-tests.lisp
 
 #Lispworks
 # From the editor run:
+(load #P"~/quicklisp/setup.lisp")
 (load #P"~/path/to/boxer-sunrise/run-core-tests.lisp")
 ```
 


### PR DESCRIPTION
Without this they all error:
`There is no package with the name QL..`
(or similar)