### PR TITLE
Improve dev setup on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,11 @@ as node and a possible server side Boxer).
   ; example on windows
   (load "Z:/quicklisp/setup.lisp")
   ```
-- Install our patched cl-freetype project
+- Install our patched cl-freetype2 project
   ```
   # substitute for your quicklisp install location
   cd ~/quicklisp/local-projects
-  git clone git@github.com:sgithens/cl-freetype2.git
-  cd cl-freetype2
-  git checkout -b lispworks-fixup origin/lispworks-fixup
+  git clone --branch=lispworks-fixup https://github.com/sgithens/cl-freetype2.git
   ```
 - Install freetype2 libraries, headers, etc
   ```
@@ -71,6 +69,8 @@ MSYS2. You may choose to use a different build system for Windows.
   ```
 
 - Add `C:\msys64\mingw64\bin` to the windows `PATH` environment variable.
+
+You also need the patched cl-freetype2 bindings, as above (clone it under `%HOMEPATH%/quicklisp/local-projects/`).
 
 ### Running Boxer
 


### PR DESCRIPTION
This takes small steps towards dev instructions working out-of-the-box on Windows 11, but ultimately, I didn't get Boxer to launch.  At least not with LispWorks Personal Edition.

- [x] Replaced some hardcoded paths with computed (taking care with drive letters).
- [x] Documented some defaults that were unobvious to me as a newbie.  
  - I wasn't initially clear that on windows I need both C freetype libs AND the patched CL wrapper.  On second reading it was pretty clear, doh, but after wasting time debugging issues already patched there I felt it's worth saying explicitly :-)
   - The concept of "home" can be confusing on Windows, depending on what one uses for "git clone" - might be WSL, or git-bash, (well probably not cygwin anymore) etc. - some of these emulate their own concept of "home dir" distinct from %HOMEPATH%.
- [ ] After the prerequisites listed in README, it's supposed to be enough to load `src/bootstrap.lisp`?  
  Well that doesn't work on a clean system, as it attempts `(asdf:load-system :boxer-sunrise)` but I hadn't fetched most of its dependencies. => `Component :CL-GLU not found, required by #<ASDF/SYSTEM:SYSTEM "boxer-sunrise">`  
  Looks like one needs something like this (but only once):
  ```
  (ql:quickload :cl-json)
  (ql:quickload :drakma)
  (ql:quickload :for)
  (ql:quickload :html-entities)
  (ql:quickload :iterate)
  (ql:quickload :pngload)
  (ql:quickload :qbase64)
  (ql:quickload :quri)
  (ql:quickload :serapeum)
  (ql:quickload :zip)
  (ql:quickload :zpng)
  (ql:quickload :3d-matrices)
  (ql:quickload :cl-opengl :verbose t)
  (ql:quickload :cl-glu :verbose t)
  ```
  Is there a way to get all deps already declared in the .asd file?  Would `(ql:quickload :boxer-sunrise)` work?
- [ ] Repeatedly running out of LispWorks PE heap limit. 💀 
  > You are approaching the heap size limit for the Personal Edition of LispWorks.
  > If you choose to continue now you are advised to save your work at regular intervals.

  Especially during `(ql:quickload :serapeum)`.  It looks like _commenting out the previous quickload lines_ reduces heap usage - that way I was able to get past serapeum and eventually get to `(asdf:load-system :boxer-sunrise)`, now with (most) dependencies installed.

- [ ] cl-opengl failing to compile:
  ```
  **++++ Error in (PACKAGE "CL-OPENGL"): 
    "OPENGL" is already a nickname for #<The OPENGL package, 298/4096 internal, 1678/4096 external>.
  ```
  Lndeed it [wants this nickname](https://github.com/3b/cl-opengl/blob/a452f1419fc1b45bc0b1c04ce2b1d08af691401d/gl/package.lisp#L32).  
  I guess the conflict is with LispWorks' own `opengl` package?  Changelog & docs/development-notes.md suggest you've had both working independently, but HOW?  

  Pretty sure at some point last week I did get cl-opengl to install and its examples to run - but I can't reproduce that now 🤷‍♂️.  

  I see there was also `(defpackage :opengl ...` that you just removed (898f9243f2655f0c6a5b2113545f28a287e73e80).  But I'm getting this nickname collision both before and after that.

  - I think for cl-opengl examples I also needed `pacman -S mingw-w64-x86_64-freeglut` ?  Is it  also needed for Boxer to run? (README only mentions freetype)

----

P.S. sbcl progress is exciting! 🎉👏   I'll probably stop banging my head against LispWorks as I don't want to shell out for a less limited version.