### PR TITLE
sunrise-20 GLFW: Stop-gap to avoid crashing on non-printable keys

### DIFF
--- a/src/boxwin/glfw/boxwin-glfw.lisp
+++ b/src/boxwin/glfw/boxwin-glfw.lisp
@@ -52,8 +52,11 @@
     ((and (eq key :escape) (eq action :press))
      (cl-glfw3:set-window-should-close))
     ((eq action :press)
-     ;;  (boxer::handle-boxer-input (character key))
-     (boxer::insert-cha boxer::*point* (character key))
+     (handler-case
+         ;;  (boxer::handle-boxer-input (character key))
+         (boxer::insert-cha boxer::*point* (character key))
+       (type-error (e)
+         (format t "~%  Error converting key to character: ~A, ignoring." e)))
      (format t "~%  the initial box now: ~A" boxer::*initial-box*)
      )
     (t


### PR DESCRIPTION
[EDIT: I'm on Linux under wayland]
When trying `sbcl --load src/bootstrap-glfw.lisp`, key presses are already appended to box (even if not re-rendered but box is logged to stdout). But touching any key that is not alphanumeric tends to crash e.g.

```
debugger invoked on a SIMPLE-TYPE-ERROR in thread
#<THREAD tid=786576 "main thread" RUNNING {10010D81B3}>:
  Symbol name is not of length one: :MINUS
```

similarly, can't test non-nil `mod-keys` because touching a mod key crashes:
```
  Symbol name is not of length one: :LEFT-SHIFT
```

With this quick fix, you can at least go through the motions of modded keys:
```
glfw3 key-callback key3: LEFT-SHIFT scancode: 50 action: PRESS mod-keys: NIL input type: KEYWORD
  Error converting key to character: Symbol name is not of length one: :LEFT-SHIFT, ignoring.
  the initial box now: #<DATA-BOX H >
glfw3 key-callback key3: A scancode: 38 action: PRESS mod-keys: (SHIFT) input type: KEYWORD
  the initial box now: #<DATA-BOX HA >
glfw3 key-callback key3: A scancode: 38 action: RELEASE mod-keys: (SHIFT) input type: KEYWORD
"key-callback nothing"
glfw3 key-callback key3: LEFT-SHIFT scancode: 50 action: RELEASE mod-keys: (SHIFT) input type: KEYWORD
```

[Even if the mods are ignored; (CHARACTER :A) returns #\A either way. I suppose it'll get better once `handle-boxer-input` can be used...]